### PR TITLE
Do not mix tabs and spaces in the same block.

### DIFF
--- a/exabgp/lib/exabgp/memory/gcdump.py
+++ b/exabgp/lib/exabgp/memory/gcdump.py
@@ -16,16 +16,16 @@ def dump():
 		if len(s) > 80: s = "%s..." % s[:80]
 
 		print "::", s
-		print "		type:", type(x)
+		print "        type:", type(x)
 		print "   referrers:", len(gc.get_referrers(x))
 		try:
-			print "	is class:", inspect.isclass(type(x))
-			print "	  module:", inspect.getmodule(x)
+			print "    is class:", inspect.isclass(type(x))
+			print "      module:", inspect.getmodule(x)
 
 			lines, line_num = inspect.getsourcelines(type(x))
-			print "	line num:", line_num
+			print "    line num:", line_num
 			for l in lines:
-				print "		line:", l.rstrip("\n")
+				print "        line:", l.rstrip("\n")
 		except:
 			pass
 

--- a/exabgp/lib/netlink/route.py
+++ b/exabgp/lib/netlink/route.py
@@ -99,7 +99,7 @@ class NetLinkRoute (object):
 			type,
 			sequence,
 			self.Flags.NLM_F_REQUEST | self.Flags.NLM_F_DUMP,
-            		pack('Bxxx', family),
+			pack('Bxxx', family),
 			{}
 		)
 
@@ -112,7 +112,7 @@ class NetLinkRoute (object):
 					if self._IGNORE_SEQ_FAULTS:
 						continue
 					raise NetLinkError("netlink seq mismatch")
-            			if mtype == self.Command.NLMSG_DONE:
+				if mtype == self.Command.NLMSG_DONE:
 					raise StopIteration()
 				elif type in self.errors:
 					raise NetLinkError(self.errors[mtype])
@@ -125,7 +125,7 @@ class NetLinkRoute (object):
 		message = self.encode(
 			type,
 			self.Flags.NLM_F_REQUEST | self.Flags.NLM_F_CREATE,
-            		pack('Bxxx', family)
+			pack('Bxxx', family)
 		)
 
 		self.socket.send(message)
@@ -137,7 +137,7 @@ class NetLinkRoute (object):
 					if self._IGNORE_SEQ_FAULTS:
 						continue
 					raise NetLinkError("netlink seq mismatch")
-            			if mtype == self.Command.NLMSG_DONE:
+				if mtype == self.Command.NLMSG_DONE:
 					raise StopIteration()
 				elif type in self.errors:
 					raise NetLinkError(self.errors[mtype])
@@ -190,10 +190,10 @@ class _InfoMessage (object):
 		self.route = route
 
 	def decode (self,data):
-    		extracted = list(unpack(self.Header.PACK,data[:self.Header.LEN]))
+		extracted = list(unpack(self.Header.PACK,data[:self.Header.LEN]))
 		attributes = Attributes().decode(data[self.Header.LEN:])
 		extracted.append(dict(attributes))
-    		return self.format(*extracted)
+		return self.format(*extracted)
 
 	def extract (self,type):
 		for data in self.route.query(type):
@@ -308,32 +308,32 @@ class Address (_InfoMessage):
 			RT_SCOPE_NOWHERE  = 0x00 # Destination does not exist
 
 		class Attribute (object):
-			IFLA_UNSPEC      = 0x00
-			IFLA_ADDRESS     = 0x01
-			IFLA_BROADCAST   = 0x02
-			IFLA_IFNAME      = 0x03
-			IFLA_MTU         = 0x04
-			IFLA_LINK        = 0x05
-		        IFLA_QDISC       = 0x06
-			IFLA_STATS       = 0x07
-			IFLA_COST        = 0x08
-			IFLA_PRIORITY    = 0x09
-			IFLA_MASTER      = 0x0A
-		        IFLA_WIRELESS    = 0x0B
-			IFLA_PROTINFO    = 0x0C
-			IFLA_TXQLEN      = 0x0D
-			IFLA_MAP         = 0x0E
-			IFLA_WEIGHT      = 0x0F
-		        IFLA_OPERSTATE   = 0x10
-			IFLA_LINKMODE    = 0x11
-			IFLA_LINKINFO    = 0x12
-			IFLA_NET_NS_PID  = 0x13
-		        IFLA_IFALIAS     = 0x14
-			IFLA_NUM_VF      = 0x15
+			IFLA_UNSPEC	 = 0x00
+			IFLA_ADDRESS	 = 0x01
+			IFLA_BROADCAST	 = 0x02
+			IFLA_IFNAME	 = 0x03
+			IFLA_MTU	 = 0x04
+			IFLA_LINK	 = 0x05
+			IFLA_QDISC	 = 0x06
+			IFLA_STATS	 = 0x07
+			IFLA_COST	 = 0x08
+			IFLA_PRIORITY	 = 0x09
+			IFLA_MASTER	 = 0x0A
+			IFLA_WIRELESS	 = 0x0B
+			IFLA_PROTINFO	 = 0x0C
+			IFLA_TXQLEN	 = 0x0D
+			IFLA_MAP	 = 0x0E
+			IFLA_WEIGHT	 = 0x0F
+			IFLA_OPERSTATE	 = 0x10
+			IFLA_LINKMODE	 = 0x11
+			IFLA_LINKINFO	 = 0x12
+			IFLA_NET_NS_PID	 = 0x13
+			IFLA_IFALIAS	 = 0x14
+			IFLA_NUM_VF	 = 0x15
 			IFLA_VFINFO_LIST = 0x16
-			IFLA_STATS64     = 0x17
-		        IFLA_VF_PORTS    = 0x18
-			IFLA_PORT_SELF   = 0x19
+			IFLA_STATS64	 = 0x17
+			IFLA_VF_PORTS	 = 0x18
+			IFLA_PORT_SELF	 = 0x19
 
 	def getAddresses (self):
 		return self.extract(self.Command.RTM_GETADDR)

--- a/examples/app_specific_peering_inboundTE/controller/participant_policies/participant_A.py
+++ b/examples/app_specific_peering_inboundTE/controller/participant_policies/participant_A.py
@@ -65,7 +65,7 @@ def policy(participant, sdx):
     prefixes_announced=bgp_get_announced_routes(sdx,'A')
     
     final_policy= (
-		   (match(dstport=80) >> sdx.fwd(participant.peers['B']))+
+                   (match(dstport=80) >> sdx.fwd(participant.peers['B']))+
                    (match(dstport=4321) >> sdx.fwd(participant.peers['C']))+
                    (match(dstport=4322) >> sdx.fwd(participant.peers['C']))+
                    (match_prefixes_set(set(prefixes_announced)) >> sdx.fwd(participant.phys_ports[0]))

--- a/examples/app_specific_peering_inboundTE/controller/participant_policies/participant_C.py
+++ b/examples/app_specific_peering_inboundTE/controller/participant_policies/participant_C.py
@@ -69,9 +69,9 @@ def policy(participant, sdx):
     prefixes_announced=bgp_get_announced_routes(sdx,'C')
     
     final_policy= (
-		   (match(dstport=4321) >> sdx.fwd(participant.phys_ports[0]))+
+                   (match(dstport=4321) >> sdx.fwd(participant.phys_ports[0]))+
                    (match(dstport=4322) >> sdx.fwd(participant.phys_ports[1]))
-		   #((match_prefixes_set(set(prefixes_announced)) >> sdx.fwd(participant.phys_ports[0])))
+                   #((match_prefixes_set(set(prefixes_announced)) >> sdx.fwd(participant.phys_ports[0])))
                   )
     
     return final_policy

--- a/examples/app_specific_peering_inboundTE/mininet/sdx_mininext.py
+++ b/examples/app_specific_peering_inboundTE/mininet/sdx_mininext.py
@@ -64,19 +64,19 @@ class QuaggaTopo( Topo ):
 
             quaggaContainer = self.addHost( name=host.name,
                                             ip=host.ip,
-					    mac=host.mac,
+                                            mac=host.mac,
                                             privateLogDir=True,
                                             privateRunDir=True,
                                             inMountNamespace=True,
                                             inPIDNamespace=True)
             self.addNodeService(node=host.name, service=quaggaSvc,
                                 nodeConfig=quaggaSvcConfig)
-	    "Attach the quaggaContainer to the IXP Fabric Switch"
+            "Attach the quaggaContainer to the IXP Fabric Switch"
             self.addLink( quaggaContainer, ixpfabric , port2=host.port)
-	
-	" Add root node for ExaBGP. ExaBGP acts as route server for SDX. "
-	root = self.addHost('exabgp', ip = '172.0.255.254/16', inNamespace = False)
-	self.addLink(root, ixpfabric, port2 = 5)
+        
+        " Add root node for ExaBGP. ExaBGP acts as route server for SDX. "
+        root = self.addHost('exabgp', ip = '172.0.255.254/16', inNamespace = False)
+        self.addLink(root, ixpfabric, port2 = 5)
         
 
 
@@ -84,29 +84,29 @@ def addInterfacesForSDXNetwork( net ):
     hosts=net.hosts
     print "Configuring participating ASs\n\n"
     for host in hosts:
-	print "Host name: ", host.name
-	if host.name=='a1':
-		host.cmd('sudo ifconfig lo:1 100.0.0.1 netmask 255.255.255.0 up')
-		host.cmd('sudo ifconfig lo:2 100.0.0.2 netmask 255.255.255.0 up')
-		host.cmd('sudo ifconfig lo:110 110.0.0.1 netmask 255.255.255.0 up')
-	if host.name=='b1':
-		host.cmd('sudo ifconfig lo:140 140.0.0.1 netmask 255.255.255.0 up')
-		host.cmd('sudo ifconfig lo:150 150.0.0.1 netmask 255.255.255.0 up')
-	if host.name=='c1':
-		host.cmd('sudo ifconfig lo:140 140.0.0.1 netmask 255.255.255.0 up')
-		host.cmd('sudo ifconfig lo:150 150.0.0.1 netmask 255.255.255.0 up')
-	if host.name=='c2':
-		host.cmd('sudo ifconfig lo:140 140.0.0.1 netmask 255.255.255.0 up')
-		host.cmd('sudo ifconfig lo:150 150.0.0.1 netmask 255.255.255.0 up')
-	if host.name == "exabgp":
-		host.cmd( 'route add -net 172.0.0.0/16 dev exabgp-eth0')
+        print "Host name: ", host.name
+        if host.name=='a1':
+            host.cmd('sudo ifconfig lo:1 100.0.0.1 netmask 255.255.255.0 up')
+            host.cmd('sudo ifconfig lo:2 100.0.0.2 netmask 255.255.255.0 up')
+            host.cmd('sudo ifconfig lo:110 110.0.0.1 netmask 255.255.255.0 up')
+        if host.name=='b1':
+            host.cmd('sudo ifconfig lo:140 140.0.0.1 netmask 255.255.255.0 up')
+            host.cmd('sudo ifconfig lo:150 150.0.0.1 netmask 255.255.255.0 up')
+        if host.name=='c1':
+            host.cmd('sudo ifconfig lo:140 140.0.0.1 netmask 255.255.255.0 up')
+            host.cmd('sudo ifconfig lo:150 150.0.0.1 netmask 255.255.255.0 up')
+        if host.name=='c2':
+            host.cmd('sudo ifconfig lo:140 140.0.0.1 netmask 255.255.255.0 up')
+            host.cmd('sudo ifconfig lo:150 150.0.0.1 netmask 255.255.255.0 up')
+        if host.name == "exabgp":
+            host.cmd( 'route add -net 172.0.0.0/16 dev exabgp-eth0')
 
 def startNetwork():
     info( '** Creating Quagga network topology\n' )
     topo = QuaggaTopo()
     global net
     net = Mininext(topo=topo, 
-		controller=lambda name: RemoteController( name, ip='127.0.0.1' ),listenPort=6633)
+                controller=lambda name: RemoteController( name, ip='127.0.0.1' ),listenPort=6633)
     
     info( '** Starting the network\n' )
     net.start()
@@ -114,7 +114,7 @@ def startNetwork():
     info( '** psaux dumps on all hosts\n' )
     for lr in net.hosts:
         if lr.name != 'exabgp':
-	    lr.cmdPrint("ps aux")
+            lr.cmdPrint("ps aux")
     
     info( '**Adding Network Interfaces for SDX Setup\n' )    
     addInterfacesForSDXNetwork(net)

--- a/examples/gec20_demo/controller/participant_policies/participant_A.py
+++ b/examples/gec20_demo/controller/participant_policies/participant_A.py
@@ -65,7 +65,7 @@ def policy(participant, sdx):
     prefixes_announced=bgp_get_announced_routes(sdx,'A')
     
     final_policy= (
-		   (match(dstport=80) >> sdx.fwd(participant.peers['B']))+
+                   (match(dstport=80) >> sdx.fwd(participant.peers['B']))+
                    (match(dstport=4321) >> sdx.fwd(participant.peers['C']))+
                    (match(dstport=4322) >> sdx.fwd(participant.peers['C']))+
                    (match_prefixes_set(set(prefixes_announced)) >> sdx.fwd(participant.phys_ports[0]))

--- a/examples/gec20_demo/controller/participant_policies/participant_C.py
+++ b/examples/gec20_demo/controller/participant_policies/participant_C.py
@@ -69,9 +69,9 @@ def policy(participant, sdx):
     prefixes_announced=bgp_get_announced_routes(sdx,'C')
     
     final_policy= (
-		   (match(dstport=4321) >> sdx.fwd(participant.phys_ports[0]))+
+                   (match(dstport=4321) >> sdx.fwd(participant.phys_ports[0]))+
                    (match(dstport=4322) >> sdx.fwd(participant.phys_ports[1]))
-		   #((match_prefixes_set(set(prefixes_announced)) >> sdx.fwd(participant.phys_ports[0])))
+                   #((match_prefixes_set(set(prefixes_announced)) >> sdx.fwd(participant.phys_ports[0])))
                   )
     
     return final_policy

--- a/examples/gec20_demo/mininet/sdx_mininext.py
+++ b/examples/gec20_demo/mininet/sdx_mininext.py
@@ -64,19 +64,19 @@ class QuaggaTopo( Topo ):
 
             quaggaContainer = self.addHost( name=host.name,
                                             ip=host.ip,
-					    mac=host.mac,
+                                            mac=host.mac,
                                             privateLogDir=True,
                                             privateRunDir=True,
                                             inMountNamespace=True,
                                             inPIDNamespace=True)
             self.addNodeService(node=host.name, service=quaggaSvc,
                                 nodeConfig=quaggaSvcConfig)
-	    "Attach the quaggaContainer to the IXP Fabric Switch"
+            "Attach the quaggaContainer to the IXP Fabric Switch"
             self.addLink( quaggaContainer, ixpfabric , port2=host.port)
-	
-	" Add root node for ExaBGP. ExaBGP acts as route server for SDX. "
-	root = self.addHost('exabgp', ip = '172.0.255.254/16', inNamespace = False)
-	self.addLink(root, ixpfabric, port2 = 5)
+        
+        " Add root node for ExaBGP. ExaBGP acts as route server for SDX. "
+        root = self.addHost('exabgp', ip = '172.0.255.254/16', inNamespace = False)
+        self.addLink(root, ixpfabric, port2 = 5)
         
 
 
@@ -84,33 +84,33 @@ def addInterfacesForSDXNetwork( net ):
     hosts=net.hosts
     print "Configuring participating ASs\n\n"
     for host in hosts:
-	print "Host name: ", host.name
-	if host.name=='a1':
-		host.cmdPrint('sudo ifconfig lo:1 100.0.0.1 netmask 255.255.255.0 up')
-		host.cmdPrint('sudo ifconfig lo:2 100.0.0.2 netmask 255.255.255.0 up')
-		host.cmdPrint('sudo ifconfig lo:110 110.0.0.1 netmask 255.255.255.0 up')
-		host.cmdPrint('sudo ifconfig -a')  
-	if host.name=='b1':
-		host.cmdPrint('sudo ifconfig lo:140 140.0.0.1 netmask 255.255.255.0 up')
-		host.cmdPrint('sudo ifconfig lo:150 150.0.0.1 netmask 255.255.255.0 up')
-		host.cmdPrint('sudo ifconfig -a')  
-	if host.name=='c1':
-		host.cmdPrint('sudo ifconfig lo:140 140.0.0.1 netmask 255.255.255.0 up')
-		host.cmdPrint('sudo ifconfig lo:150 150.0.0.1 netmask 255.255.255.0 up')
-		host.cmdPrint('sudo ifconfig -a')  
-	if host.name=='c2':
-		host.cmdPrint('sudo ifconfig lo:140 140.0.0.1 netmask 255.255.255.0 up')
-		host.cmdPrint('sudo ifconfig lo:150 150.0.0.1 netmask 255.255.255.0 up')
-		host.cmdPrint('sudo ifconfig -a')  
-	if host.name == "exabgp":
-		host.cmdPrint( 'route add -net 172.0.0.0/16 dev exabgp-eth0')
+        print "Host name: ", host.name
+        if host.name=='a1':
+            host.cmdPrint('sudo ifconfig lo:1 100.0.0.1 netmask 255.255.255.0 up')
+            host.cmdPrint('sudo ifconfig lo:2 100.0.0.2 netmask 255.255.255.0 up')
+            host.cmdPrint('sudo ifconfig lo:110 110.0.0.1 netmask 255.255.255.0 up')
+            host.cmdPrint('sudo ifconfig -a')  
+        if host.name=='b1':
+            host.cmdPrint('sudo ifconfig lo:140 140.0.0.1 netmask 255.255.255.0 up')
+            host.cmdPrint('sudo ifconfig lo:150 150.0.0.1 netmask 255.255.255.0 up')
+            host.cmdPrint('sudo ifconfig -a')  
+        if host.name=='c1':
+            host.cmdPrint('sudo ifconfig lo:140 140.0.0.1 netmask 255.255.255.0 up')
+            host.cmdPrint('sudo ifconfig lo:150 150.0.0.1 netmask 255.255.255.0 up')
+            host.cmdPrint('sudo ifconfig -a')  
+        if host.name=='c2':
+            host.cmdPrint('sudo ifconfig lo:140 140.0.0.1 netmask 255.255.255.0 up')
+            host.cmdPrint('sudo ifconfig lo:150 150.0.0.1 netmask 255.255.255.0 up')
+            host.cmdPrint('sudo ifconfig -a')  
+        if host.name == "exabgp":
+            host.cmdPrint( 'route add -net 172.0.0.0/16 dev exabgp-eth0')
 
 def startNetwork():
     info( '** Creating Quagga network topology\n' )
     topo = QuaggaTopo()
     global net
     net = Mininext(topo=topo, 
-		controller=lambda name: RemoteController( name, ip='127.0.0.1' ),listenPort=6633)
+                controller=lambda name: RemoteController( name, ip='127.0.0.1' ),listenPort=6633)
     
     info( '** Starting the network\n' )
     net.start()
@@ -121,7 +121,7 @@ def startNetwork():
     info( '** psaux dumps on all hosts\n' )
     for lr in net.hosts:
         if lr.name != 'exabgp':
-	    lr.cmdPrint("ps aux")
+            lr.cmdPrint("ps aux")
     
     #info( '** Dumping host connections\n' )
     #dumpNodeConnections(net.hosts)

--- a/examples/sigcomm14_mininet/controller/participant_policies/participant_A.py
+++ b/examples/sigcomm14_mininet/controller/participant_policies/participant_A.py
@@ -65,7 +65,7 @@ def policy(participant, sdx):
     prefixes_announced=bgp_get_announced_routes(sdx,'A')
     
     final_policy= (
-		   (match(dstport=80) >> sdx.fwd(participant.peers['B']))+
+                   (match(dstport=80) >> sdx.fwd(participant.peers['B']))+
                    (match(dstport=4321) >> sdx.fwd(participant.peers['C']))+
                    (match(dstport=4322) >> sdx.fwd(participant.peers['C']))+
                    (match_prefixes_set(set(prefixes_announced)) >> sdx.fwd(participant.phys_ports[0]))

--- a/examples/sigcomm14_mininet/controller/participant_policies/participant_C.py
+++ b/examples/sigcomm14_mininet/controller/participant_policies/participant_C.py
@@ -69,9 +69,9 @@ def policy(participant, sdx):
     prefixes_announced=bgp_get_announced_routes(sdx,'C')
     
     final_policy= (
-		   (match(dstport=4321) >> sdx.fwd(participant.phys_ports[0]))+
+                   (match(dstport=4321) >> sdx.fwd(participant.phys_ports[0]))+
                    (match(dstport=4322) >> sdx.fwd(participant.phys_ports[1]))
-		   #((match_prefixes_set(set(prefixes_announced)) >> sdx.fwd(participant.phys_ports[0])))
+                   #((match_prefixes_set(set(prefixes_announced)) >> sdx.fwd(participant.phys_ports[0])))
                   )
     
     return final_policy

--- a/examples/sigcomm14_mininet/mininet/sdx_mininext.py
+++ b/examples/sigcomm14_mininet/mininet/sdx_mininext.py
@@ -64,19 +64,19 @@ class QuaggaTopo( Topo ):
 
             quaggaContainer = self.addHost( name=host.name,
                                             ip=host.ip,
-					    mac=host.mac,
+                                            mac=host.mac,
                                             privateLogDir=True,
                                             privateRunDir=True,
                                             inMountNamespace=True,
                                             inPIDNamespace=True)
             self.addNodeService(node=host.name, service=quaggaSvc,
                                 nodeConfig=quaggaSvcConfig)
-	    "Attach the quaggaContainer to the IXP Fabric Switch"
+            "Attach the quaggaContainer to the IXP Fabric Switch"
             self.addLink( quaggaContainer, ixpfabric , port2=host.port)
-	
-	" Add root node for ExaBGP. ExaBGP acts as route server for SDX. "
-	root = self.addHost('exabgp', ip = '172.0.255.254/16', inNamespace = False)
-	self.addLink(root, ixpfabric, port2 = 5)
+        
+        " Add root node for ExaBGP. ExaBGP acts as route server for SDX. "
+        root = self.addHost('exabgp', ip = '172.0.255.254/16', inNamespace = False)
+        self.addLink(root, ixpfabric, port2 = 5)
         
 
 
@@ -84,33 +84,33 @@ def addInterfacesForSDXNetwork( net ):
     hosts=net.hosts
     print "Configuring participating ASs\n\n"
     for host in hosts:
-	print "Host name: ", host.name
-	if host.name=='a1':
-		host.cmdPrint('sudo ifconfig lo:1 100.0.0.1 netmask 255.255.255.0 up')
-		host.cmdPrint('sudo ifconfig lo:2 100.0.0.2 netmask 255.255.255.0 up')
-		host.cmdPrint('sudo ifconfig lo:110 110.0.0.1 netmask 255.255.255.0 up')
-		host.cmdPrint('sudo ifconfig -a')  
-	if host.name=='b1':
-		host.cmdPrint('sudo ifconfig lo:140 140.0.0.1 netmask 255.255.255.0 up')
-		host.cmdPrint('sudo ifconfig lo:150 150.0.0.1 netmask 255.255.255.0 up')
-		host.cmdPrint('sudo ifconfig -a')  
-	if host.name=='c1':
-		host.cmdPrint('sudo ifconfig lo:140 140.0.0.1 netmask 255.255.255.0 up')
-		host.cmdPrint('sudo ifconfig lo:150 150.0.0.1 netmask 255.255.255.0 up')
-		host.cmdPrint('sudo ifconfig -a')  
-	if host.name=='c2':
-		host.cmdPrint('sudo ifconfig lo:140 140.0.0.1 netmask 255.255.255.0 up')
-		host.cmdPrint('sudo ifconfig lo:150 150.0.0.1 netmask 255.255.255.0 up')
-		host.cmdPrint('sudo ifconfig -a')  
-	if host.name == "exabgp":
-		host.cmdPrint( 'route add -net 172.0.0.0/16 dev exabgp-eth0')
+        print "Host name: ", host.name
+        if host.name=='a1':
+            host.cmdPrint('sudo ifconfig lo:1 100.0.0.1 netmask 255.255.255.0 up')
+            host.cmdPrint('sudo ifconfig lo:2 100.0.0.2 netmask 255.255.255.0 up')
+            host.cmdPrint('sudo ifconfig lo:110 110.0.0.1 netmask 255.255.255.0 up')
+            host.cmdPrint('sudo ifconfig -a')  
+        if host.name=='b1':
+            host.cmdPrint('sudo ifconfig lo:140 140.0.0.1 netmask 255.255.255.0 up')
+            host.cmdPrint('sudo ifconfig lo:150 150.0.0.1 netmask 255.255.255.0 up')
+            host.cmdPrint('sudo ifconfig -a')  
+        if host.name=='c1':
+            host.cmdPrint('sudo ifconfig lo:140 140.0.0.1 netmask 255.255.255.0 up')
+            host.cmdPrint('sudo ifconfig lo:150 150.0.0.1 netmask 255.255.255.0 up')
+            host.cmdPrint('sudo ifconfig -a')  
+        if host.name=='c2':
+            host.cmdPrint('sudo ifconfig lo:140 140.0.0.1 netmask 255.255.255.0 up')
+            host.cmdPrint('sudo ifconfig lo:150 150.0.0.1 netmask 255.255.255.0 up')
+            host.cmdPrint('sudo ifconfig -a')  
+        if host.name == "exabgp":
+            host.cmdPrint( 'route add -net 172.0.0.0/16 dev exabgp-eth0')
 
 def startNetwork():
     info( '** Creating Quagga network topology\n' )
     topo = QuaggaTopo()
     global net
     net = Mininext(topo=topo, 
-		controller=lambda name: RemoteController( name, ip='127.0.0.1' ),listenPort=6633)
+                controller=lambda name: RemoteController( name, ip='127.0.0.1' ),listenPort=6633)
     
     info( '** Starting the network\n' )
     net.start()
@@ -121,7 +121,7 @@ def startNetwork():
     info( '** psaux dumps on all hosts\n' )
     for lr in net.hosts:
         if lr.name != 'exabgp':
-	    lr.cmdPrint("ps aux")
+            lr.cmdPrint("ps aux")
     
     #info( '** Dumping host connections\n' )
     #dumpNodeConnections(net.hosts)

--- a/lib/vnh_assignment.py
+++ b/lib/vnh_assignment.py
@@ -265,7 +265,7 @@ def step5b_expand_policy_with_vnhop(policy, participant_id, sdx, acc=[]):
         elif isinstance(policy, fwd):
 
             if len(list(acc)):
-            	xcl = 1 # TODO: clean this later
+                xcl = 1 # TODO: clean this later
         return policy
 
 def step5b(policy, participant, sdx):

--- a/tests/set-operations/test-setOperations.py
+++ b/tests/set-operations/test-setOperations.py
@@ -67,7 +67,7 @@ def getPrefixes(pfile,VNH_2_IP,prefixes_announced,prefixes):
             temp=line.split(' ')
             neighbor=temp[0]
             prefix=temp[1].split('\n')[0]
-	    if prefix not in plist:
+            if prefix not in plist:
                 plist.append(prefix)
                 prefixes['p'+str(i)]=IPv4Network(prefix)
                 i+=1


### PR DESCRIPTION
The codebase mixes spaces and tabs in the Python code. PEP8 recommends spaces.

I've only fixed those lines which mixed tabs and spaces in the same block, since those lead to syntax errors by the Python parser.
